### PR TITLE
Use a module for loading in external methods

### DIFF
--- a/lib/doorkeeper/grants_assertion.rb
+++ b/lib/doorkeeper/grants_assertion.rb
@@ -20,7 +20,7 @@ end
 module Doorkeeper
   class Config
     option :resource_owner_from_assertion, default: (lambda do |routes|
-        warn(I18n.translate("doorkeeper.errors.messages.assertion_flow_not_configured"))
+        warn(I18n.t("doorkeeper.errors.messages.assertion_flow_not_configured"))
         nil
       end)
   end

--- a/lib/doorkeeper/grants_assertion/railtie.rb
+++ b/lib/doorkeeper/grants_assertion/railtie.rb
@@ -1,11 +1,9 @@
 module Doorkeeper
   module GrantsAssertion
     class Railtie < ::Rails::Railtie
-
       initializer "doorkeeper.grants_assertion" do
         Doorkeeper::ApplicationController.send :include, Doorkeeper::GrantsAssertion
       end
-
     end
   end
 end


### PR DESCRIPTION
Overriding `ApplicationController` was causing a lot of issues when using other flows such as the auth code flow once this gem is installed, see https://github.com/doorkeeper-gem/doorkeeper-grants_assertion/issues/2 for more details.

Let me know if there is anything else I would need to do to prep this… Thanks!
