### PR TITLE
include Doorkeeper::GrantsAssertion in Doorkeeper::Helpers::Controller

### DIFF
--- a/lib/doorkeeper/grants_assertion/railtie.rb
+++ b/lib/doorkeeper/grants_assertion/railtie.rb
@@ -2,7 +2,7 @@ module Doorkeeper
   module GrantsAssertion
     class Railtie < ::Rails::Railtie
       initializer "doorkeeper.grants_assertion" do
-        Doorkeeper::ApplicationController.send :include, Doorkeeper::GrantsAssertion
+        Doorkeeper::Helpers::Controller.send :include, Doorkeeper::GrantsAssertion
       end
     end
   end


### PR DESCRIPTION
I've changed railtie to fix error below.
```
NoMethodError (undefined method `resource_owner_from_assertion' for #<Doorkeeper::TokensController:0x007ff48fcb9ce8>)
```