### PR TITLE
Add specs and upgrade gems

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,22 @@ Doorkeeper.configure do
     user_data = JSON.parse(response.body)
     User.find_by_facebook_id(user_data['id'])
   end
-  
+
   # add your supported grant types and other extensions
   grant_flows %w(assertion authorization_code implicit password client_credentials)
 end
 ```
 
+If you want to ensure that resource owners can only receive access tokens scoped to a specific application, you'll need to add that logic in to the definition as well:
+
+```ruby
+Doorkeeper.configure do
+  resource_owner_from_assertion do
+    Doorkeeper::Application.find_by!(uid: params[:client_id]) #will raise an exception if not found
+    facebook = URI.parse('https://graph.facebook.com/me?access_token=' +
+    params[:assertion])
+    ....continue with authentication lookup....
+```
 ___
 
 IETF standard: http://tools.ietf.org/html/draft-ietf-oauth-assertions-16

--- a/doorkeeper-grants_assertion.gemspec
+++ b/doorkeeper-grants_assertion.gemspec
@@ -13,9 +13,9 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "railties", ">= 3.1"
-  s.add_dependency "doorkeeper", ">= 1.3"
+  s.add_dependency "doorkeeper", ">= 2.0"
   s.add_development_dependency "rspec-rails", ">= 2.11.4"
-  s.add_development_dependency "capybara", "~> 1.1.2"
+  s.add_development_dependency "capybara", ">= 2.2.0"
   s.add_development_dependency "factory_girl", "~> 2.6.4"
   s.add_development_dependency "generator_spec", "~> 0.9.0"
   s.add_development_dependency "database_cleaner", "~> 1.2.0"

--- a/spec/dummy/app/controllers/full_protected_resources_controller.rb
+++ b/spec/dummy/app/controllers/full_protected_resources_controller.rb
@@ -1,6 +1,5 @@
 class FullProtectedResourcesController < ApplicationController
-  doorkeeper_for :index
-  doorkeeper_for :show, scopes: [:admin]
+  before_action :doorkeeper_authorize!
 
   def index
     render text: 'index'

--- a/spec/dummy/app/controllers/metal_controller.rb
+++ b/spec/dummy/app/controllers/metal_controller.rb
@@ -1,9 +1,9 @@
 class MetalController < ActionController::Metal
   include AbstractController::Callbacks
   include ActionController::Head
-  include Doorkeeper::Helpers::Filter
+  include Doorkeeper::Helpers::Controller
 
-  doorkeeper_for :all
+  before_action :doorkeeper_authorize!
 
   def index
     self.response_body = { ok: true }.to_json

--- a/spec/dummy/app/controllers/semi_protected_resources_controller.rb
+++ b/spec/dummy/app/controllers/semi_protected_resources_controller.rb
@@ -1,5 +1,5 @@
 class SemiProtectedResourcesController < ApplicationController
-  doorkeeper_for :index
+  before_action :doorkeeper_authorize!, only: [:index]
 
   def index
     render text: 'protected index'

--- a/spec/requests/flows/assertion_spec.rb
+++ b/spec/requests/flows/assertion_spec.rb
@@ -1,33 +1,78 @@
 require 'spec_helper_integration'
 
-feature 'Resource Owner Assertion Flow inproperly set up' do
-  background do
+describe 'Resource Owner Assertion Flow inproperly set up', type: :request do
+  before do
+    config_is_set(:resource_owner_from_assertion) { nil }
     client_exists
     create_resource_owner
   end
 
   context 'with valid user assertion' do
-    scenario "should not issue new token" do
+    it "should not issue new token" do
       expect {
         post assertion_endpoint_url(client: @client, resource_owner: @resource_owner)
       }.to_not change { Doorkeeper::AccessToken.count }
 
-      should_have_json 'error', 'invalid_resource_owner'
-      should_have_json 'error_description', translated_error_message(:invalid_resource_owner)
+      should_have_json 'error', 'invalid_grant'
+      should_have_json 'error_description', translated_error_message(:invalid_grant)
       expect(response.status).to eq(401)
     end
   end
 end
 
-feature 'Resource Owner Assertion Flow' do
-  background do
+describe 'Resource Owner Assertion Flow', type: :request do
+  before do
     config_is_set(:resource_owner_from_assertion) { User.where(assertion: params[:assertion]).first }
     client_exists
     create_resource_owner
   end
 
+  context "with invalid client/application information" do
+
+    it "should not create an access token" do
+      expect {
+        post assertion_endpoint_url(
+          client_id: 'not-real',
+          client_secret: 'not-real',
+          redirect_uri: 'http://fake-redirect.com'
+        )
+      }.to_not change { Doorkeeper::AccessToken.count }
+    end
+  end
+
+  context "with missing client/application information" do
+    let(:no_client_params) {
+      {
+        grant_type: "assertion",
+        assertion: @resource_owner.assertion
+      }
+    }
+
+    it "should create an access token" do
+      expect {
+        post "/oauth/token?#{build_query(no_client_params)}"
+      }.to change { Doorkeeper::AccessToken.count }.by(1)
+    end
+
+    context "when client is required as part of assertion lookup" do
+
+      before do
+        config_is_set(:resource_owner_from_assertion) {
+          Doorkeeper::Application.find_by!(uid: params[:client_id])
+          User.where(assertion: params[:assertion]).first
+        }
+      end
+
+      it "should not create an access token" do
+        expect {
+          post "/oauth/token?#{build_query(no_client_params)}"
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+
   context 'with valid user assertion' do
-    scenario "should issue new token" do
+    it "should issue new token" do
       expect {
         post assertion_endpoint_url(client: @client, resource_owner: @resource_owner)
       }.to change { Doorkeeper::AccessToken.count }.by(1)
@@ -37,7 +82,15 @@ feature 'Resource Owner Assertion Flow' do
       should_have_json 'access_token',  token.token
     end
 
-    scenario "should issue a refresh token if enabled" do
+    it "should associate the token with the appropriate application" do
+      post assertion_endpoint_url(client: @client, resource_owner: @resource_owner)
+
+      token = Doorkeeper::AccessToken.first
+
+      expect(token.application_id).to eq(@client.id)
+    end
+
+    it "should issue a refresh token if enabled" do
       config_is_set(:refresh_token_enabled, true)
 
       post assertion_endpoint_url(client: @client, resource_owner: @resource_owner)
@@ -50,23 +103,23 @@ feature 'Resource Owner Assertion Flow' do
   end
 
   context "with invalid user assertion" do
-    scenario "should not issue new token with bad assertion" do
+    it "should not issue new token with bad assertion" do
       expect {
         post assertion_endpoint_url( client: @client, assertion: 'i_dont_exist' )
       }.to_not change { Doorkeeper::AccessToken.count }
 
-      should_have_json 'error', 'invalid_resource_owner'
-      should_have_json 'error_description', translated_error_message(:invalid_resource_owner)
+      should_have_json 'error', 'invalid_grant'
+      should_have_json 'error_description', translated_error_message(:invalid_grant)
       expect(response.status).to eq(401)
     end
 
-    scenario "should not issue new token without assertion" do
+    it "should not issue new token without assertion" do
       expect {
         post assertion_endpoint_url( client: @client )
       }.to_not change { Doorkeeper::AccessToken.count }
 
-      should_have_json 'error', 'invalid_resource_owner'
-      should_have_json 'error_description', translated_error_message(:invalid_resource_owner)
+      should_have_json 'error', 'invalid_grant'
+      should_have_json 'error_description', translated_error_message(:invalid_grant)
       expect(response.status).to eq(401)
     end
 


### PR DESCRIPTION
This changeset upgrades a number of gems, moves the doorkeeper dependency to 2.0, and reworks/adds additional specs for behavior. I do not know if you're open to such large changes in dependencies but figured I'd submit anyway.

I originally forked this after reading #11 - I believe the specs should make the behavior clearer for these situations. This gem delegates the requests to an `OAuth::PasswordAccessTokenRequest` which means the following:

 * When no client credentials are passed but a valid resource owner is it will happily return an access token not belonging to any specific application.
 * When invalid client credentials are passed (regardless of resource owner) it will not create an access token.
 * When valid client credentials are passed along with a valid resource owner it will create an access token belonging to the application matching the client credentials.

This behavior seems to be appropriate for password access tokens, but there's a bit of extra discussion around that here: https://github.com/doorkeeper-gem/doorkeeper/issues/669

If you do want to prevent access tokens from being created when no client credentials are passed this would need to be built in to your `resource_owner_from_assertion` definition - just check those params are present and if not, raise an exception.

Let me know your thoughts.