### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: ruby
+rvm:
+ - 2.0
+ - 2.1
+ - 2.2
+script: bundle exec rake spec

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Doorkeeper - Assertion Grant Extension
 
+[![Travis CI](https://img.shields.io/travis/doorkeeper-gem/doorkeeper-grants_assertion/master.svg)](https://travis-ci.org/doorkeeper-gem/doorkeeper-grants_assertion)
+
 Assertion grant extension for Doorkeeper. Born from:
 https://github.com/doorkeeper-gem/doorkeeper/pull/249
 


### PR DESCRIPTION
Hey there, I did the honors of adding a basic `.travis.yml` for this.  All the specs are (predictably) passing as you can see [here](https://travis-ci.org/hummingbird-me/doorkeeper-grants_assertion).

I'd also like to adopt this gem since I'm hoping to use it for our next-generation social login over at @hummingbird-me and it clearly needs a bit more work before it's quite production-ready. #9 especially seems important