### PR TITLE
Fixes "wrong number of argument" when using doorkeeper 3.1.0

### DIFF
--- a/lib/doorkeeper/request/assertion.rb
+++ b/lib/doorkeeper/request/assertion.rb
@@ -4,7 +4,9 @@ module Doorkeeper
       attr_accessor :credentials, :resource_owner, :server
 
       def initialize(server)
-        @credentials, @resource_owner, @server = server.credentials, server.resource_owner_from_assertion, server
+        @credentials = server.credentials
+        @resource_owner = server.resource_owner_from_assertion
+        @server = server
       end
 
       def request

--- a/lib/doorkeeper/request/assertion.rb
+++ b/lib/doorkeeper/request/assertion.rb
@@ -1,16 +1,10 @@
 module Doorkeeper
   module Request
     class Assertion
-      def self.build(server)
-        new(server.credentials, server.resource_owner_from_assertion, server)
-      end
-
       attr_accessor :credentials, :resource_owner, :server
 
-      def initialize(credentials, resource_owner, server)
-        @credentials = credentials
-        @resource_owner = resource_owner
-        @server = server
+      def initialize(server)
+        @credentials, @resource_owner, @server = server.credentials, server.resource_owner_from_assertion, server
       end
 
       def request


### PR DESCRIPTION
This [commit](https://github.com/doorkeeper-gem/doorkeeper/commit/e676684ebab17452c2abb8e7667eec1eb1452f34) has refactored the Doorkeeper authorization request and exchanged a call for the `build` to `new`.

That change made impossible to call Assertion request authorizer.