### PR TITLE
Updated Doorkeeper dependency to 4.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # Define Rails version
 gem 'rails', ENV['rails']
 
-gem 'doorkeeper', '>= 4.0.0.rc4'
+gem 'doorkeeper', '>= 4.0.0'
 
 gem 'pry'
 gem 'sqlite3'

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # Define Rails version
 gem 'rails', ENV['rails']
 
-gem 'doorkeeper', '>= 3.1.0'
+gem 'doorkeeper', '>= 4.0.0.rc4'
 
 gem 'pry'
 gem 'sqlite3'

--- a/doorkeeper-grants_assertion.gemspec
+++ b/doorkeeper-grants_assertion.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "railties", ">= 3.1"
-  s.add_dependency "doorkeeper", ">= 2.0"
+  s.add_dependency "doorkeeper", ">= 4.0.0.rc4"
   s.add_development_dependency "rspec-rails", ">= 2.11.4"
   s.add_development_dependency "capybara", ">= 2.2.0"
   s.add_development_dependency "factory_girl", "~> 2.6.4"

--- a/doorkeeper-grants_assertion.gemspec
+++ b/doorkeeper-grants_assertion.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "railties", ">= 3.1"
-  s.add_dependency "doorkeeper", ">= 4.0.0.rc4"
+  s.add_dependency "doorkeeper", ">= 4.0.0"
   s.add_development_dependency "rspec-rails", ">= 2.11.4"
   s.add_development_dependency "capybara", ">= 2.2.0"
   s.add_development_dependency "factory_girl", "~> 2.6.4"

--- a/lib/doorkeeper/request/assertion.rb
+++ b/lib/doorkeeper/request/assertion.rb
@@ -1,10 +1,11 @@
 module Doorkeeper
   module Request
     class Assertion
-      attr_accessor :credentials, :resource_owner, :server
+      attr_accessor :resource_owner, :server
+
+      delegate :credentials, :parameters, to: :server
 
       def initialize(server)
-        @credentials = server.credentials
         @resource_owner = server.resource_owner_from_assertion
         @server = server
       end
@@ -12,13 +13,24 @@ module Doorkeeper
       def request
         @request ||= OAuth::PasswordAccessTokenRequest.new(
           Doorkeeper.configuration,
-          credentials,
+          client,
           resource_owner,
-          server.parameters)
+          parameters
+        )
       end
 
       def authorize
         request.authorize
+      end
+
+      private
+
+      def client
+        if credentials
+          server.client
+        elsif parameters[:client_id]
+          server.client_via_uid
+        end
       end
     end
   end

--- a/spec/requests/flows/assertion_spec.rb
+++ b/spec/requests/flows/assertion_spec.rb
@@ -13,8 +13,8 @@ describe 'Resource Owner Assertion Flow inproperly set up', type: :request do
         post assertion_endpoint_url(client: @client, resource_owner: @resource_owner)
       }.to_not change { Doorkeeper::AccessToken.count }
 
-      should_have_json 'error', 'invalid_resource_owner'
-      should_have_json 'error_description', translated_error_message(:invalid_resource_owner)
+      should_have_json 'error', 'invalid_grant'
+      should_have_json 'error_description', translated_error_message(:invalid_grant)
       expect(response.status).to eq(401)
     end
   end
@@ -108,8 +108,8 @@ describe 'Resource Owner Assertion Flow', type: :request do
         post assertion_endpoint_url( client: @client, assertion: 'i_dont_exist' )
       }.to_not change { Doorkeeper::AccessToken.count }
 
-      should_have_json 'error', 'invalid_resource_owner'
-      should_have_json 'error_description', translated_error_message(:invalid_resource_owner)
+      should_have_json 'error', 'invalid_grant'
+      should_have_json 'error_description', translated_error_message(:invalid_grant)
       expect(response.status).to eq(401)
     end
 
@@ -118,8 +118,8 @@ describe 'Resource Owner Assertion Flow', type: :request do
         post assertion_endpoint_url( client: @client )
       }.to_not change { Doorkeeper::AccessToken.count }
 
-      should_have_json 'error', 'invalid_resource_owner'
-      should_have_json 'error_description', translated_error_message(:invalid_resource_owner)
+      should_have_json 'error', 'invalid_grant'
+      should_have_json 'error_description', translated_error_message(:invalid_grant)
       expect(response.status).to eq(401)
     end
 

--- a/spec/requests/flows/assertion_spec.rb
+++ b/spec/requests/flows/assertion_spec.rb
@@ -13,8 +13,8 @@ describe 'Resource Owner Assertion Flow inproperly set up', type: :request do
         post assertion_endpoint_url(client: @client, resource_owner: @resource_owner)
       }.to_not change { Doorkeeper::AccessToken.count }
 
-      should_have_json 'error', 'invalid_grant'
-      should_have_json 'error_description', translated_error_message(:invalid_grant)
+      should_have_json 'error', 'invalid_resource_owner'
+      should_have_json 'error_description', translated_error_message(:invalid_resource_owner)
       expect(response.status).to eq(401)
     end
   end
@@ -108,8 +108,8 @@ describe 'Resource Owner Assertion Flow', type: :request do
         post assertion_endpoint_url( client: @client, assertion: 'i_dont_exist' )
       }.to_not change { Doorkeeper::AccessToken.count }
 
-      should_have_json 'error', 'invalid_grant'
-      should_have_json 'error_description', translated_error_message(:invalid_grant)
+      should_have_json 'error', 'invalid_resource_owner'
+      should_have_json 'error_description', translated_error_message(:invalid_resource_owner)
       expect(response.status).to eq(401)
     end
 
@@ -118,8 +118,8 @@ describe 'Resource Owner Assertion Flow', type: :request do
         post assertion_endpoint_url( client: @client )
       }.to_not change { Doorkeeper::AccessToken.count }
 
-      should_have_json 'error', 'invalid_grant'
-      should_have_json 'error_description', translated_error_message(:invalid_grant)
+      should_have_json 'error', 'invalid_resource_owner'
+      should_have_json 'error_description', translated_error_message(:invalid_resource_owner)
       expect(response.status).to eq(401)
     end
 


### PR DESCRIPTION
This pull request updates the Doorkeeper dependency to 4.0.0.rc4 and contains the required changes to the assertion and specs to get the specs passing again.

Not sure how you guys want to handle the major version bump? I guess we should really start tagging the master branch?

Either way, I was worried that this project may get left behind if it is not brought up to date with Doorkeeper so thought I'd at least get the ball rolling. 😄 