### PR TITLE
Add documentation for Facebook and Google

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Doorkeeper.configure do
     params[:assertion])
     ....continue with authentication lookup....
 ```
+More complete examples, also for other providers may be found in the [wiki](https://github.com/doorkeeper-gem/doorkeeper-grants_assertion/wiki).
 ___
 
 IETF standard: http://tools.ietf.org/html/rfc7521


### PR DESCRIPTION
I have added a documentation for authenticating against 3rd party providers taking google and facebook as an example. I was receiving a lot of questions from the developers I consult.

I hope it will be helpful.