### PR TITLE
Relax Devise dependency

### DIFF
--- a/doorkeeper-grants_assertion.gemspec
+++ b/doorkeeper-grants_assertion.gemspec
@@ -36,5 +36,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "omniauth-facebook", "~> 4.0.0"
   s.add_development_dependency "omniauth-google-oauth2", "~> 0.5.3"
   s.add_development_dependency "webmock", "~> 3.3.0"
-  s.add_development_dependency "devise", "~> 4.4.3"
+  s.add_development_dependency "devise", ">= 4.4.3"
 end

--- a/spec/doorkeeper/grants_assertion_spec.rb
+++ b/spec/doorkeeper/grants_assertion_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 RSpec.describe Doorkeeper::GrantsAssertion::VERSION do
-  it { is_expected.to eq("0.2.0") }
+  it { is_expected.to eq("0.3.0") }
 end


### PR DESCRIPTION
As stated in the subject - let's not restrict users to use some specific minor versions (also allows to use it with newer Rails)